### PR TITLE
Ensuring Vercel’s dashboard build doesn’t get triggered

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,1 @@
+hopr-stake

--- a/hopr-stake/package.json
+++ b/hopr-stake/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nextjs-ethereum-starter",
+  "name": "hopr-stake",
   "version": "independent",
   "private": true,
   "scripts": {


### PR DESCRIPTION
See [this](https://github.com/vercel/vercel/discussions/6490#discussioncomment-1029542) discussion and [documentation](https://vercel.com/guides/prevent-uploading-sourcepaths-with-vercelignore) about `.vercelignore`